### PR TITLE
refactoring: Entity 의 equals, hashcode의 필드접근 getter 로 변경

### DIFF
--- a/src/main/java/com/jk/projectboard/domain/Article.java
+++ b/src/main/java/com/jk/projectboard/domain/Article.java
@@ -62,11 +62,11 @@ public class Article extends AuditingFields {
         if (this == o) return true;
         if (!(o instanceof Article that)) return false;
         // 영속화 되지 않았다면 다른 값으로 취급함
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/jk/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/jk/projectboard/domain/ArticleComment.java
@@ -45,11 +45,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/jk/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/jk/projectboard/domain/UserAccount.java
@@ -50,11 +50,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
Entity들의 equals(), hashcode() 의 값 비교를 위한 필드 직접 접근을 getter로 변경
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 정상적으로 수행하도록 수정